### PR TITLE
Adding some adjustments to take into account Require.JS Sugar Syntax

### DIFF
--- a/lib/transformers/amdToCjs.js
+++ b/lib/transformers/amdToCjs.js
@@ -41,17 +41,27 @@ Object.defineProperty(module.exports, '__visitors', {
       var moduleBody = this.transformedModuleBody(path);
       if (moduleBody) {
         var p = path.parent;
+        var statements = [];
 
-        if (!dependencies || dependencies.length === 0) {
-          // define({obj: prop}); signature
-          if (n.AssignmentExpression.check(moduleBody))
-            moduleBody = b.expressionStatement(moduleBody);
+        if (dependencies && dependencies.length) {
+          statements.push.apply(statements, dependencies);
+        }
 
-          p.replace(moduleBody);
+        // define({obj: prop}); signature
+        if (n.AssignmentExpression.check(moduleBody)) {
+          moduleBody = b.expressionStatement(moduleBody);
         }
-        else {
-          p.replace.apply(p, dependencies.concat(moduleBody));
+
+        if (moduleBody.body && moduleBody.body.length) {
+          statements.push.apply(statements, moduleBody.body);
+        } else {
+          statements.push(moduleBody);
         }
+
+        statements.reverse().forEach(function(statement) {
+          p.insertAfter(statement);
+        });
+        p.replace();
       }
 
       // replace the AMD CallExpression itself
@@ -60,7 +70,12 @@ Object.defineProperty(module.exports, '__visitors', {
 
     isAMDDefinition: function(path) {
       var node = path.node;
-      return isCallExpressionNamed('require') || isCallExpressionNamed('define');
+      return !isCjs() && (isCallExpressionNamed('require') || isCallExpressionNamed('define'));
+
+      function isCjs() {
+        return (isCallExpressionNamed('require') &&
+          n.Literal.check(node.arguments[0]))
+      }
 
       function isCallExpressionNamed(name) {
         return (n.CallExpression.check(node) &&

--- a/test/cases/amdToCjs.js
+++ b/test/cases/amdToCjs.js
@@ -3,6 +3,11 @@ define(function() {
   return 'hello world';
 });
 
+define(function(require) {
+  var a = require('rjs-require');
+  return a;
+});
+
 define({
   hello: 'world'
 });

--- a/test/cases/amdToCjs.out.js
+++ b/test/cases/amdToCjs.out.js
@@ -1,7 +1,7 @@
 /** Top level comments shouldn’t be duplicated. */
-{
-  module.exports = 'hello world';
-}
+module.exports = 'hello world';
+var a = require('rjs-require');
+module.exports = a;
 
 module.exports = {
   hello: 'world'
@@ -9,7 +9,5 @@ module.exports = {
 
 var soup = require('alphabet');
 require('novar');
-{
-  window.init();
-  module.exports = soup.eatWith('spoon');
-}
+window.init();
+module.exports = soup.eatWith('spoon');


### PR DESCRIPTION
Require.JS exposes the ability to write an intemediary format using
"Sugar Syntax", which is very similar to CJS. These changes (and tests)
should help support handling transitioning Sugar Syntax as well as
other AMD definitions.

The original parser code did a couple things a little strangely:
1. It would take define definitions to just the block statement, which would require more parsing down the road.
   
   ```
   define(function() { return 'foo'; })
   ```
   
   would turn to
   
   ```
   {
     module.exports = 'foo';
   }
   ```
   
   instead of just 
   
   ```
   module.exports = 'foo';
   ```
2. It also couldn't handle sugar syntax, that is, a partial translation of dependencies into CJS [see more info here](http://requirejs.org/docs/whyamd.html#sugar)
   
   ```
   define(function(require) {
     var foo = require('foo');
     return foo;
   });
   ```
   
   This will now result in
   
   ```
   var foo = require('foo');
   module.exports = foo;
   ```
   
   as expected.
